### PR TITLE
update cache directly after sources.list was changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     owner: root
     group: root
     mode: 0644
+  register: apt_config_updated
   when: apt_manage_sources_list
   tags:
     - configuration
@@ -16,7 +17,7 @@
 - name: update
   apt:
     update_cache: true
-    cache_valid_time: "{{ apt_update_cache_valid_time }}"
+    cache_valid_time: "{{ 0 if apt_config_updated is defined and apt_config_updated.changed else apt_update_cache_valid_time }}"
   when: apt_update
   tags:
     - configuration


### PR DESCRIPTION
fixes #7 

With this change we are able to change the `apt_ubuntu_mirror` without errors.

tested on Ubuntu 12.04, 14.04 and 16.04!

```
-deb mirror://mirrors.ubuntu.com/mirrors.txt precise multiverse
-deb-src mirror://mirrors.ubuntu.com/mirrors.txt precise multiverse
-deb mirror://mirrors.ubuntu.com/mirrors.txt precise-updates multiverse
-deb-src mirror://mirrors.ubuntu.com/mirrors.txt precise-updates multiverse
+deb http://de.archive.ubuntu.com/ubuntu/ precise multiverse
+deb-src http://de.archive.ubuntu.com/ubuntu/ precise multiverse
+deb http://de.archive.ubuntu.com/ubuntu/ precise-updates multiverse
+deb-src http://de.archive.ubuntu.com/ubuntu/ precise-updates multiverse

 # # N.B. software from this repository may not have been tested as
 # # extensively as that contained in the main release, although it includes


RUNNING HANDLER [tersmitten.apt : update] **************************************
ok: [dev-ansible-xenial] => {"cache_update_time": 1473243056, "cache_updated": true, "changed": false}
ok: [dev-ansible-trusty] => {"cache_update_time": 1473243057, "cache_updated": true, "changed": false}
ok: [dev-ansible-precise] => {"cache_update_time": 1473243057, "cache_updated": true, "changed": false}
```