### PR TITLE
Make apt_backports_enable work for Ubuntu and Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Manage packages and up(date|grade)s in Debian-like systems.
 * `apt_manage_sources_list`: [default: `false`]: Whether or not to manage `/etc/apt/sources.list`
 * `apt_ubuntu_mirror`: [default: `mirror://mirrors.ubuntu.com/mirrors.txt`]: The mirror to use
 * `apt_src_enable`: [default: `true`]: Whether or not to enable source code repositories
+* `apt_backports_enable`: [default: `true`]: Whether or not to enable the `backports` repository
 * `apt_ubuntu_universe_enable`: [default: `true`]: Whether or not to enable the `universe` repository
 * `apt_ubuntu_multiverse_enable`: [default: `true`]: Whether or not to enable the `multiverse` repository
-* `apt_ubuntu_backports_enable`: [default: `true`]: Whether or not to enable the `backports` repository
+* `apt_ubuntu_backports_enable`: [default: `true`]: Whether or not to enable the `backports` repository [deprecated in favour of `apt_backports_enable`]
 * `apt_ubuntu_partner_enable`: [default: `false`]: Whether or not to enable the `partner` repository
 * `apt_ubuntu_extras_enable`: [default: `false`]: Whether or not to enable the `extras` repository (only applies to < 16.04)
-* `apt_debian_mirror`: [default: `http://ftp.nl.debian.org/debian/`]: The mirror to use
+* `apt_debian_mirror`: [default: `http://deb.debian.org/debian/`]: The mirror to use
 * `apt_debian_contrib_nonfree_enable`: [default: `false`]: Whether or not to enable the `contrib` `non-free` repository
 
 * `apt_dependencies`: [default: `[python-apt, aptitude]`]: General dependencies for apt modules to work

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 apt_manage_sources_list: false
 
 apt_src_enable: true
+apt_backports_enable: true
 
 # Ubuntu specific
 apt_ubuntu_mirror: mirror://mirrors.ubuntu.com/mirrors.txt
@@ -12,7 +13,7 @@ apt_ubuntu_backports_enable: true
 apt_ubuntu_partner_enable: false
 apt_ubuntu_extras_enable: false
 # Debian specific
-apt_debian_mirror: http://ftp.nl.debian.org/debian/
+apt_debian_mirror: http://deb.debian.org/debian/
 apt_debian_contrib_nonfree_enable: false
 
 apt_dependencies:

--- a/templates/etc/apt/sources.list.Debian.j2
+++ b/templates/etc/apt/sources.list.Debian.j2
@@ -17,3 +17,12 @@ deb {{ apt_debian_mirror }} {{ ansible_lsb.codename }}-updates main
 deb {{ apt_debian_mirror }} {{ ansible_lsb.codename }} contrib non-free
 {{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_lsb.codename }} contrib non-free
 {% endif %}
+
+# # N.B. software from this repository may not have been tested as
+# # extensively as that contained in the main release, although it includes
+# # newer versions of some applications which may provide useful features.
+{% if apt_backports_enable %}
+deb {{ apt_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib non-free
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib non-free
+{% endif %}
+

--- a/templates/etc/apt/sources.list.Ubuntu.j2
+++ b/templates/etc/apt/sources.list.Ubuntu.j2
@@ -37,7 +37,7 @@ deb {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-updates multivers
 # # newer versions of some applications which may provide useful features.
 # # Also, please note that software in backports WILL NOT receive any review
 # # or updates from the Ubuntu security team.
-{% if apt_ubuntu_backports_enable %}
+{% if apt_backports_enable or apt_ubuntu_backports_enable %}
 deb {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-backports main restricted universe multiverse
 {{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-backports main restricted universe multiverse
 {% endif %}


### PR DESCRIPTION
Thanks for this role!

Just a small change to give one general variable `apt_backports_enable` which works for Ubuntu and Debian. Further, I changed the debian mirror to the Content Delivery Network of Debian, so, always the fastest server will be chosen.