### PR TITLE
set changed_when to false when running apt update

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
   apt:
     update_cache: true
     cache_valid_time: "{{ 0 if apt_config_updated is defined and apt_config_updated.changed else apt_update_cache_valid_time }}"
+  changed_when: false
   when: apt_update
   tags:
     - configuration


### PR DESCRIPTION
IMHO it would make more sense to not mark it a change when ansible only ran an apt update.