### PR TITLE
Use python3-apt as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 sudo: required
-dist: trusty
+dist: bionic
 
 language: python
-python: "2.7"
+python: "3.6"
 
 env:
   - ANSIBLE_VERSION=latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -rf $HOME/.cache
 # ansible
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc libffi-dev libssl-dev && \
   apt-get clean
-RUN pip install ansible==2.3.2.0
+RUN pip install ansible==2.5.0
 RUN rm -rf $HOME/.cache
 
 # provision

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage packages and up(date|grade)s in Debian-like systems.
 
 #### Requirements
 
-* `python-apt`
+* `python3-apt`
 * `aptitude`
 
 #### Variables
@@ -23,7 +23,7 @@ Manage packages and up(date|grade)s in Debian-like systems.
 * `apt_debian_mirror`: [default: `http://deb.debian.org/debian/`]: The mirror to use
 * `apt_debian_contrib_nonfree_enable`: [default: `false`]: Whether or not to enable the `contrib` `non-free` repository
 
-* `apt_dependencies`: [default: `[python-apt, aptitude]`]: General dependencies for apt modules to work
+* `apt_dependencies`: [default: `[python3-apt, aptitude]`]: General dependencies for apt modules to work
 * `apt_update`: [default: `true`]: Whether or not to update
 * `apt_update_cache_valid_time`: [default: `3600`]: Number of seconds the apt cache stays valid
 * `apt_upgrade`: [default: `true`]: Whether or not to upgrade

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ apt_debian_mirror: http://deb.debian.org/debian/
 apt_debian_contrib_nonfree_enable: false
 
 apt_dependencies:
-  - python-apt
+  - python3-apt
   - aptitude
 
 apt_update: true


### PR DESCRIPTION
This PR changes the `apt_dependencies` to use the Python 3 package `python3-apt` as default. Python 2 reached its EOL and therefore any Python 2 packages should no longer be used. All Debian and Ubuntu distributions ship Python 3, therefore python3-apt is the way to go nowadays.