### PR TITLE
Add option to configure apt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ Thumbs.db
 vagrant_ansible_inventory_*
 ansible.cfg
 
-# Other files #
-###############
-!empty
+# Python: Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+.eggs/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Manage packages and up(date|grade)s in Debian-like systems.
 * `apt_debian_mirror`: [default: `http://deb.debian.org/debian/`]: The mirror to use
 * `apt_debian_contrib_nonfree_enable`: [default: `false`]: Whether or not to enable the `contrib` `non-free` repository
 
+* `apt_manage_sources_list`: [default: `false`]: Whether or not to manage the apt configuration file `/etc/apt/apt.conf`
+* `apt_config`: [default: `{}`]: Configuration entries for `/etc/apt/apt.conf` (key-value pairs, possibly nested). See [example section](#example) for example usage.
+
 * `apt_dependencies`: [default: `[python-apt, aptitude]`]: General dependencies for apt modules to work
 * `apt_update`: [default: `true`]: Whether or not to update
 * `apt_update_cache_valid_time`: [default: `3600`]: Number of seconds the apt cache stays valid
@@ -46,6 +49,27 @@ None
 ```yaml
 ---
 - hosts: all
+  vars:
+    # install packages
+    apt_install:
+      - git
+      - htop
+
+    # remove packages
+    apt_autoremove: true
+    apt_remove_purge: true
+    apt_remove:
+      - plymouth
+
+    # manage apt configuration
+    apt_manage_config: true
+    apt_config:
+      APT:
+        Install-Recommends: false
+        Install-Suggests: false
+        Get:
+          Fix-Broken: true
+
   roles:
     - apt
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 # defaults file for apt
 ---
 apt_manage_sources_list: false
+apt_manage_config: false
 
 apt_src_enable: true
 apt_backports_enable: true
@@ -15,6 +16,8 @@ apt_ubuntu_extras_enable: false
 # Debian specific
 apt_debian_mirror: http://deb.debian.org/debian/
 apt_debian_contrib_nonfree_enable: false
+
+apt_config: {}
 
 apt_dependencies:
   - python-apt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,19 @@
 # tasks file for apt
 ---
-- name: update configuration file - /etc/apt/sources.list
+- name: update apt configuration file - /etc/apt/apt.conf
+  template:
+    src: etc/apt/apt.conf.j2
+    dest: /etc/apt/apt.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: apt_manage_config
+  tags:
+    - configuration
+    - apt
+    - apt-configuration
+
+- name: update sources list file - /etc/apt/sources.list
   template:
     src: "etc/apt/sources.list.{{ ansible_distribution }}.j2"
     dest: /etc/apt/sources.list

--- a/templates/etc/apt/apt.conf.j2
+++ b/templates/etc/apt/apt.conf.j2
@@ -1,0 +1,25 @@
+#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+{{ ansible_managed | comment('c') }}
+{% macro format_value(key, value) %}
+  {%- if value is list %}
+{{ key }} {
+    {% for item in value %}
+  "{{ item }}";
+    {% endfor %}
+};
+  {%- elif value is mapping %}
+{{ key }} {
+    {% for k, v in value.items() %}
+  {{ format_value(k, v) | indent(2) }}
+    {% endfor %}
+};
+  {%- elif value is boolean %}
+{{ key }} "{{ value | ternary('true', 'false') }}";
+  {%- else %}
+{{ key }} "{{ value }}";
+  {%- endif %}
+{% endmacro %}
+
+{% for key, value in apt_config.items() %}
+{{ format_value(key, value) }}
+{% endfor %}

--- a/test_plugins/bool.py
+++ b/test_plugins/bool.py
@@ -1,0 +1,21 @@
+class TestModule(object):
+
+    def tests(self):
+        return {
+            'boolean': self.is_boolean,
+        }
+
+    def is_boolean(self, value):
+        """Test if a value is of type boolean.
+
+        Jinja2 >= 2.11 comes a built-in boolean test, but most systems will ship
+        an older version. Until Ansible adopts the new Jinja2 version, this test
+        can be used as a alternative.
+
+        Args:
+            value: A value, that shall be type tested
+
+        Returns:
+            bool: True, if value is of type boolean, False otherwise.
+        """
+        return isinstance(value, bool)

--- a/test_plugins/list.py
+++ b/test_plugins/list.py
@@ -1,0 +1,22 @@
+class TestModule(object):
+
+    def tests(self):
+        return {
+            'list': self.is_list,
+        }
+
+    def is_list(self, value):
+        """Test if a value is of type list.
+
+        Jinja2 provides the tests `iterable` and `sequence`, but those also
+        match strings and dicts and can therefore not be used to determine, if a
+        value is a true list type. Therefore I wrote this test, which solves
+        this shortcoming.
+
+        Args:
+            value: A value, that shall be type tested
+
+        Returns:
+            bool: True, if value is of type list, False otherwise.
+        """
+        return isinstance(value, list)


### PR DESCRIPTION
This PR adds the possibility to configure APT with this role. When `ansible_manage_config` is set to `true`, the role will generate the `/etc/apt/apt.conf` using the configuration specified by `ansible_config`.

Example:

```yaml
apt_manage_config: true
apt_config:
  APT:
    Install-Recommends: false
    Install-Suggests: false
    Get:
      Fix-Broken: true
```

will result in (`/etc/apt/apt.conf`):
```plaintext
//
// This file is managed by Ansible. Do NOT edit this file manually!
//

APT {
  Install-Recommends "false";
  Install-Suggests "false";
  Get {
    Fix-Broken "true";
  };
};
```