### PR TITLE
Allow us to set a custom security repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Manage packages and up(date|grade)s in Debian-like systems.
 
 * `apt_manage_sources_list`: [default: `false`]: Whether or not to manage `/etc/apt/sources.list`
 * `apt_ubuntu_mirror`: [default: `mirror://mirrors.ubuntu.com/mirrors.txt`]: The mirror to use
+* `apt_ubuntu_security_mirror`: [default: `http://security.ubuntu.com/ubuntu`]: The security-mirror to use
 * `apt_src_enable`: [default: `true`]: Whether or not to enable source code repositories
 * `apt_backports_enable`: [default: `true`]: Whether or not to enable the `backports` repository
 * `apt_ubuntu_universe_enable`: [default: `true`]: Whether or not to enable the `universe` repository
@@ -21,6 +22,7 @@ Manage packages and up(date|grade)s in Debian-like systems.
 * `apt_ubuntu_partner_enable`: [default: `false`]: Whether or not to enable the `partner` repository
 * `apt_ubuntu_extras_enable`: [default: `false`]: Whether or not to enable the `extras` repository (only applies to < 16.04)
 * `apt_debian_mirror`: [default: `http://deb.debian.org/debian/`]: The mirror to use
+* `apt_debian_security_mirror`: [default: `http://security.debian.org/`]: The security-mirror to use
 * `apt_debian_contrib_nonfree_enable`: [default: `false`]: Whether or not to enable the `contrib` `non-free` repository
 
 * `apt_dependencies`: [default: `[python-apt, aptitude]`]: General dependencies for apt modules to work

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ apt_backports_enable: true
 
 # Ubuntu specific
 apt_ubuntu_mirror: mirror://mirrors.ubuntu.com/mirrors.txt
+apt_ubuntu_security_mirror: http://security.ubuntu.com/ubuntu
 apt_ubuntu_universe_enable: true
 apt_ubuntu_multiverse_enable: true
 apt_ubuntu_backports_enable: true
@@ -14,6 +15,7 @@ apt_ubuntu_partner_enable: false
 apt_ubuntu_extras_enable: false
 # Debian specific
 apt_debian_mirror: http://deb.debian.org/debian/
+apt_debian_security_mirror: http://security.debian.org/
 apt_debian_contrib_nonfree_enable: false
 
 apt_dependencies:

--- a/templates/etc/apt/sources.list.Debian.j2
+++ b/templates/etc/apt/sources.list.Debian.j2
@@ -3,8 +3,8 @@
 deb {{ apt_debian_mirror }} {{ ansible_lsb.codename }} main
 {{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_lsb.codename }} main
 
-deb http://security.debian.org/ {{ ansible_lsb.codename }}/updates main
-{{ '# ' if not apt_src_enable else '' }}deb-src http://security.debian.org/ {{ ansible_lsb.codename }}/updates main
+deb {{ apt_debian_security_mirror }} {{ ansible_lsb.codename }}/updates main
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_security_mirror }} {{ ansible_lsb.codename }}/updates main
 
 # {{ ansible_lsb.codename }}-updates, previously known as 'volatile'
 deb {{ apt_debian_mirror }} {{ ansible_lsb.codename }}-updates main

--- a/templates/etc/apt/sources.list.Ubuntu.j2
+++ b/templates/etc/apt/sources.list.Ubuntu.j2
@@ -42,15 +42,15 @@ deb {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-backports main re
 {{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_ubuntu_mirror }} {{ ansible_distribution_release }}-backports main restricted universe multiverse
 {% endif %}
 
-deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main restricted
-{{ '# ' if not apt_src_enable else '' }}deb-src http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main restricted
+deb {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security main restricted
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security main restricted
 {% if apt_ubuntu_universe_enable %}
-deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security universe
-{{ '# ' if not apt_src_enable else '' }}deb-src http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security universe
+deb {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security universe
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security universe
 {% endif %}
 {% if apt_ubuntu_multiverse_enable %}
-deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security multiverse
-{{ '# ' if not apt_src_enable else '' }}deb-src http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security multiverse
+deb {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security multiverse
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security multiverse
 {% endif %}
 
 # # This software is not part of Ubuntu, but is offered by Canonical and the


### PR DESCRIPTION
This might be useful in enterprise environments, and will be usefull for
Raspberry PIs, which use custom security repos.