### PR TITLE
Move autoremove after remove

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,16 +82,6 @@
     - apt
     - apt-clean
 
-- name: autoremove
-  apt:
-    autoremove: true
-    dpkg_options: "{{ apt_upgrade_dpkg_options | join(',') }}"
-  when: apt_autoremove
-  tags:
-    - configuration
-    - apt
-    - apt-autoremove
-
 - name: install
   apt:
     name: "{{ apt_install }}"
@@ -110,3 +100,13 @@
     - configuration
     - apt
     - apt-remove
+
+- name: autoremove
+  apt:
+    autoremove: true
+    dpkg_options: "{{ apt_upgrade_dpkg_options | join(',') }}"
+  when: apt_autoremove
+  tags:
+    - configuration
+    - apt
+    - apt-autoremove


### PR DESCRIPTION
Running `autoremove` after `remove` means we clean up any dependencies that
might be left behind after removing a package. Doing it the other way
means we might leave dependencies behind after running this role, and
you have to run the role multiple times to clear them out.