### PR TITLE
Fix "Failed to lock apt for exclusive operation"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,18 @@
     - apt
     - apt-configuration
 
+- name: ensure directory exists - /var/lib/apt/lists/
+  file:
+    path: /var/lib/apt/lists/
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - configuration
+    - apt
+    - apt-update
+
 - name: update
   apt:
     update_cache: true


### PR DESCRIPTION
Fix "Failed to lock apt for exclusive operation: Failed to lock directory /var/lib/apt/lists/: E:Could not open lock file /var/lib/apt/lists/lock - open (2: No such file or directory)"