### PR TITLE
Add non-free-firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Manage packages and up(date|grade)s in Debian-like systems.
 * `apt_ubuntu_extras_enable`: [default: `false`]: Whether or not to enable the `extras` repository (only applies to < 16.04)
 * `apt_debian_mirror`: [default: `http://deb.debian.org/debian/`]: The mirror to use
 * `apt_debian_security_mirror`: [default: `http://security.debian.org/`]: The security-mirror to use
-* `apt_debian_contrib_nonfree_enable`: [default: `false`]: Whether or not to enable the `contrib` `non-free` repository
+* `apt_debian_contrib_nonfree_enable`: [default: `false`]: Whether or not to enable the `contrib` `non-free` `non-free-firmware` repository
 
 * `apt_dependencies`: [default: `[python3-apt, aptitude]`]: General dependencies for apt modules to work
 * `apt_update`: [default: `true`]: Whether or not to update

--- a/templates/etc/apt/sources.list.Debian.j2
+++ b/templates/etc/apt/sources.list.Debian.j2
@@ -1,5 +1,7 @@
 {{ ansible_managed | comment }}
 
+{% set nonfree = (ansible_distribution_major_version is version('12', '<=')) | ternary("non-free non-free-firmware", "non-free") -%}
+
 deb {{ apt_debian_mirror }} {{ ansible_distribution_release }} main
 {{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_distribution_release }} main
 
@@ -14,15 +16,15 @@ deb {{ apt_debian_mirror }} {{ ansible_distribution_release }}-updates main
 # but have dependencies not in main (possibly packaged for Debian in non-free).
 # Non-free contains software that does not comply with the DFSG.
 {% if apt_debian_contrib_nonfree_enable %}
-deb {{ apt_debian_mirror }} {{ ansible_distribution_release }} contrib non-free
-{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_distribution_release }} contrib non-free
+deb {{ apt_debian_mirror }} {{ ansible_distribution_release }} contrib {{ nonfree }}
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_distribution_release }} contrib {{ nonfree }}
 {% endif %}
 
 # # N.B. software from this repository may not have been tested as
 # # extensively as that contained in the main release, although it includes
 # # newer versions of some applications which may provide useful features.
 {% if apt_backports_enable %}
-deb {{ apt_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib non-free
-{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib non-free
+deb {{ apt_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib {{ nonfree }}
+{{ '# ' if not apt_src_enable else '' }}deb-src {{ apt_debian_mirror }} {{ ansible_distribution_release }}-backports main contrib {{ nonfree }}
 {% endif %}
 


### PR DESCRIPTION
This PR adds repo for `non-free-firmware`. I did not change the flag to enable `non-free` as I think `non-free-firmware` fits well under `non-free`.