### PR TITLE
fix: handle missing software-properties-common on Debian 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             ansible-version: '>=9, <10'
           - distro: debian11
           - distro: debian12
+          - distro: debian13
           - distro: ubuntu1804
             ansible-version: '>=9, <10'
           - distro: ubuntu2004

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,4 +3,6 @@
   hosts: all
   become: true
   roles:
-    - ../../../
+    - role: ../../../
+      vars:
+        apt_manage_sources_list: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,17 @@
 # vars file
 ---
-apt_dependencies_pre:
-  - software-properties-common
-  - dirmngr
-  - apt-transport-https
+apt_dependencies_pre: >-
+  {{
+    (
+      []
+      if (
+        ansible_distribution == 'Debian' and
+        ansible_distribution_major_version is version('13', '>=')
+      )
+      else ['software-properties-common']
+    )
+    + ['dirmngr', 'apt-transport-https']
+  }}
 apt_sources_list_file: /etc/apt/sources.list
 apt_ubuntu_sources_file: /etc/apt/sources.list.d/ubuntu.sources
 apt_apt_conf_file: /etc/apt/apt.conf


### PR DESCRIPTION
## Summary

Fix Debian 13 support when `apt_manage_sources_list` is enabled.

On Debian 13, the role fails during `install dependencies (pre)` because it tries to install `software-properties-common`, which is not available.

This change:
- skips `software-properties-common` on Debian 13+
- updates the Molecule scenario so the failing code path is actually exercised
- adds Debian 13 to the CI matrix

## Problem

The failure happens in the `manage sources.list` block when `apt_manage_sources_list: true`:

```text
No package matching 'software-properties-common' is available
```

The current Molecule scenario did not expose this because it did not enable apt_manage_sources_list.

## Validation

Tested locally with:

MOLECULE_DISTRO=debian13 molecule test

Before this patch:

- the scenario failed on software-properties-common

After this patch:

- the scenario passes on Debian 13